### PR TITLE
exercise: interface basics

### DIFF
--- a/01-parsingdata/README.md
+++ b/01-parsingdata/README.md
@@ -1,0 +1,7 @@
+### Step by Step
+
+- [x] testare le 3 funzioni
+- [x] separare open e reader in 2 diverse funzioni & testare il reader
+- [ ] 3 pacchetti: 1x risorsa, 1 x formato e 1 x logica di calcolo
+- [ ] 1 pacchetto alternativo che legge risorsa da http invece che da un file
+- [ ] creiamo un server per poi deployarlo su kubernetes

--- a/01-parsingdata/formats/csv/csv.go
+++ b/01-parsingdata/formats/csv/csv.go
@@ -1,0 +1,19 @@
+package csv
+
+import (
+	"encoding/csv"
+	"io"
+)
+
+// more on interfaces: https://github.com/golang/go/wiki/CodeReviewComments#interfaces
+type Getter interface {
+	Get() (io.ReadCloser, error)
+}
+
+func Read(r io.Reader) ([][]string, error) {
+	f := csv.NewReader(r)
+	f.Comma = '\t'
+	records, err := f.ReadAll()
+
+	return records, err
+}

--- a/01-parsingdata/formats/csv/csv_test.go
+++ b/01-parsingdata/formats/csv/csv_test.go
@@ -1,0 +1,39 @@
+package csv_test
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/simox-83/CodeClinic/01-parsingdata/formats/csv"
+)
+
+func TestRead(t *testing.T) {
+	assert := assert.New(t)
+
+	table, err := csv.Read(&testGetter{
+		data: `date	time	Air_Temp	Barometric_Press	Dew_Point	Relative_Humidity	Wind_Dir	Wind_Gust	Wind_Speed
+2015_01_01	00:02:43	19.50	30.62	14.78	81.60	159.78	14.00	 9.20
+2015_01_01	00:02:52	19.50	30.62	14.78	81.60	159.78	14.00	 9.20
+2015_01_01	00:07:43	19.50	30.61	14.66	81.20	155.63	11.00	 8.60`})
+
+	assert.IsType([][]string{}, table)
+	assert.NoError(err)
+
+	assert.Len(table, 4)
+	assert.Len(table[1], 9)
+
+	assert.Equal(table[3][4], "14.66")
+
+}
+
+type testGetter struct {
+	data string
+}
+
+func (g *testGetter) Get() (io.ReadCloser, error) {
+	return ioutil.NopCloser(strings.NewReader(g.data)), nil
+}

--- a/01-parsingdata/homework
+++ b/01-parsingdata/homework
@@ -1,5 +1,0 @@
-testare le 3 funzioni
-separare open e reader in 2 diverse funzioni & testare il reader
-3 pacchetti: 1x risorsa, 1 x formato e 1 x logica di calcolo
-1 pacchetto alternativo che legge risorsa da http invece che da un file
-creiamo un server per poi deployarlo su kubernetes


### PR DESCRIPTION
exercise:
1. make unit tests of package `formats/csv` pass, without touching unit tests
1. remove `main_test.go:TestRun`
1. in `main.go` use `formats/csv.Read` instead of `main.read`
1. from `01-parsingdata` run `go test -cover ./...` and ensure that all tests are passing; note that code coverage should increase (now it is 67.9%)

more about interfaces: https://github.com/golang/go/wiki/CodeReviewComments#interfaces